### PR TITLE
fixing bugs for indexing parents

### DIFF
--- a/src/indexdata.py
+++ b/src/indexdata.py
@@ -43,7 +43,7 @@ import logging
 import lxml.etree as ET
 from logging.handlers import TimedRotatingFileHandler
 from time import sleep
-#import pickle Not used as of Øystein Godøy, METNO/FOU, 2023-04-10 
+#import pickle Not used as of Øystein Godøy, METNO/FOU, 2023-04-10
 from shapely.geometry import box
 from shapely.wkt import loads
 from shapely.geometry import mapping
@@ -415,12 +415,12 @@ class MMD4SolR:
             lmu_note = []
             # FIXME check if this works correctly
             #Only one last_metadata_update element
-            if isinstance(last_metadata_update['mmd:update'], dict): 
+            if isinstance(last_metadata_update['mmd:update'], dict):
                     lmu_datetime.append(str(last_metadata_update['mmd:update']['mmd:datetime']))
                     lmu_type.append(last_metadata_update['mmd:update']['mmd:type'])
                     lmu_note.append(last_metadata_update['mmd:update']['mmd:note'])
             # multiple last_metadata_update elements
-            else: 
+            else:
                 for i,e in enumerate(last_metadata_update['mmd:update']):
                     lmu_datetime.append(str(e['mmd:datetime']))
                     lmu_type.append(e['mmd:type'])
@@ -907,7 +907,7 @@ class MMD4SolR:
 
         """ Keywords """
         """
-        Added double indexing of GCMD keywords. keywords_gcmd  (and keywords_wigos) are for faceting in SolR. 
+        Added double indexing of GCMD keywords. keywords_gcmd  (and keywords_wigos) are for faceting in SolR.
         What is shown in data portal is keywords_keyword.
         """
         self.logger.info("Processing keywords")
@@ -1036,9 +1036,9 @@ class MMD4SolR:
             dataset_citation_elements = self.mydoc['mmd:mmd']['mmd:dataset_citation']
 
             #Only one element
-            if isinstance(dataset_citation_elements, dict): 
+            if isinstance(dataset_citation_elements, dict):
                 # make it an iterable list
-                dataset_citation_elements = [dataset_citation_elements] 
+                dataset_citation_elements = [dataset_citation_elements]
 
             for dataset_citation in dataset_citation_elements:
                 for k, v in dataset_citation.items():
@@ -1066,8 +1066,8 @@ class MMD4SolR:
                             v += 'T12:00:00Z'
                     mydict['dataset_citation_{}'.format(element_suffix)] = v
 
-        """ 
-        Quality control 
+        """
+        Quality control
         """
         self.logger.info("Processing quality control information")
         if 'mmd:quality_control' in self.mydoc['mmd:mmd'] and self.mydoc['mmd:mmd']['mmd:quality_control'] != None:
@@ -1081,7 +1081,7 @@ class MMD4SolR:
         encoded_xml_string = base64.b64encode(xml_string)
         xml_b64 = (encoded_xml_string).decode('utf-8')
         mydict['mmd_xml_file'] = xml_b64
-        
+
         ## Set default parent child relation. No parent, no child.
         """Set defualt parent/child flags"""
         self.logger.info("Setting default parent/child relations")
@@ -1137,7 +1137,7 @@ class IndexMMD:
     Primary function to index records, rewritten to expect list input
     """
     def index_record(self, records2ingest, addThumbnail, wms_layer=None, wms_style=None, wms_zoom_level=0, add_coastlines=True, projection=ccrs.PlateCarree(), wms_timeout=120, thumbnail_extent=None):
-        # FIXME, update the text below Øystein Godøy, METNO/FOU, 2023-03-19 
+        # FIXME, update the text below Øystein Godøy, METNO/FOU, 2023-03-19
         """ Add thumbnail to SolR
             Args:
                 input_record() : input MMD file to be indexed in SolR
@@ -1394,7 +1394,7 @@ class IndexMMD:
 
         return(featureType)
 
-    # FIXME check if can be deleted, Øystein Godøy, METNO/FOU, 2023-03-21 
+    # FIXME check if can be deleted, Øystein Godøy, METNO/FOU, 2023-03-21
     # Not sure if this is needed onwards, but keeping for now.
     def search(self):
         """ Require Id as input """
@@ -1409,7 +1409,7 @@ class IndexMMD:
     Use solr real-time get to check if a parent is already indexed,
     and have been marked as parent
     """
-    def find_parent_in_index(id):
+    def find_parent_in_index(self, id):
         res = requests.get(mySolRc+'/get?id='+id, auth=authentication)
         res.raise_for_status()
         return res.json()
@@ -1418,7 +1418,7 @@ class IndexMMD:
     Update the parent document we got from solr.
     some fields need to be removed for solr to accept the update.
     """
-    def solr_updateparent(parent):
+    def solr_updateparent(self, parent):
         if 'full_text' in parent:
             parent.pop('full_text')
         if 'bbox__maxX' in parent:
@@ -1569,7 +1569,7 @@ def main(argv):
             continue
         fileno += 1
 
-        """ 
+        """
         Convert to the SolR format needed
         """
         mylog.info('Converting to SolR format.')
@@ -1623,11 +1623,11 @@ def main(argv):
             # FIXME, need more robustness...
             mylog.warning('This part of parent/child relations is yet not tested.')
             continue
-            parent = find_parent_in_index(id)
-            parent = solr_updateparent(parent)
-            mysolr.add([parent])
+            parent = mysolr.find_parent_in_index(id)
+            parent = mysolr.solr_updateparent(parent)
+            mysolr.solrc.add([parent])
         else:
-            # Assuming found in the current batch of files, then set to parent... Not sure if this is needed onwards, but discussion on how isParent works is needed Øystein Godøy, METNO/FOU, 2023-03-31 
+            # Assuming found in the current batch of files, then set to parent... Not sure if this is needed onwards, but discussion on how isParent works is needed Øystein Godøy, METNO/FOU, 2023-03-31
             i = 0
             for rec in files2ingest:
                 if rec['id'] == id:


### PR DESCRIPTION
There are some bugs in the code for indexing parents. There are functions in the IndexMMD class that are not encoded with a 'self' argument. They are also not being called as functions belonging to classes.

I don't think the code I am editing is actually being used yet but is required for NBS.