### PR TITLE
adding Data server landing page related info type

### DIFF
--- a/src/indexdata.py
+++ b/src/indexdata.py
@@ -385,6 +385,7 @@ class MMD4SolR:
                               'Data management plan':'data_management_plan',
                               'Other documentation':'other_documentation',
                               'Software': 'software',
+                              'Data server landing page' : 'data_server_landing_page',
                              }
 
         # Create OrderedDict which will contain all elements for SolR


### PR DESCRIPTION
This should be the only modification needed to support indexing of "Data server landing page". Closes #63 